### PR TITLE
Change enqueueing into LPUSH to maintain FIFO semantics

### DIFF
--- a/enqueue.go
+++ b/enqueue.go
@@ -91,7 +91,7 @@ func EnqueueWithOptions(queue, class string, args interface{}, opts EnqueueOptio
 	if err != nil {
 		return "", 0, err
 	}
-	queueSize, err := redis.Int(conn.Do("rpush", queueKey(queue), bytes))
+	queueSize, err := redis.Int(conn.Do("lpush", queueKey(queue), bytes))
 	if err != nil {
 		return "", 0, err
 	}


### PR DESCRIPTION
@timehop/backend :eyes: pls

As [discussed](https://timehop.slack.com/archives/backend/p1450826567002939), `go-workers` is working as a LIFO queue. The right side of list is the _head_ according to how jobs are [popped off of the queue](https://github.com/jrallison/go-workers/blob/a5368356aa61a226ca34f130ea9c312eda3d8d25/fetcher.go#L70). _However_, `workers.Enqueue` does an `RPUSH`, which puts the newly enqueued job at the head of the queue.

This PR changes the semantics from LIFO to FIFO.

![selfie-0](http://i.imgur.com/UXNOU8k.gif)
